### PR TITLE
fix categories

### DIFF
--- a/apps/polytope/rules/polytopes.rules
+++ b/apps/polytope/rules/polytopes.rules
@@ -18,6 +18,9 @@
 
 object Polytope {
 
+        # @topic category properties/Database
+        # Database properties
+
 	# @category Database
 	# The unique ID of the polytope in the database.
 	property _id : String;


### PR DESCRIPTION
at some point in the online-docs polymake branch category warnings where implemented
now everytime I start polymake a warning shows up concerning the poly_db extension

this commit fixes that
